### PR TITLE
Fixed fd leak in nfs.c

### DIFF
--- a/factor/nfs/nfs.c
+++ b/factor/nfs/nfs.c
@@ -656,6 +656,7 @@ void nfs(fact_obj_t *fobj)
 					fwrite(relatLine, sizeof(char), strlen(relatLine), dat);
 					job.current_rels++;
 				}
+				fclose(relatFile);
 			}
 			fclose(logFile);
 			fclose(dat);


### PR DESCRIPTION
I stumbled upon fd limit on a c165 job with cadoMsieve. Tracked the problem down to the leak of the file descriptor for reading relations.