### PR TITLE
Escape AVX-512-only ECM vector functions

### DIFF
--- a/factor/avx-ecm/vecarith52_special.c
+++ b/factor/avx-ecm/vecarith52_special.c
@@ -11269,4 +11269,19 @@ void vectsqr_redc(vec_bignum_t* a, vec_bignum_t* c, vec_bignum_t* n, vec_bignum_
     vectmul_redc(a, a, c, n, s, mdata);
     return;
 }
+
+
+
+#else
+
+void veckmul_redc(vec_bignum_t* a, vec_bignum_t* b, vec_bignum_t* c, vec_bignum_t* n, vec_bignum_t* s, vec_monty_t* mdata)
+{
+    return;
+}
+
+void vecksqr_redc(vec_bignum_t* a, vec_bignum_t* c, vec_bignum_t* n, vec_bignum_t* s, vec_monty_t* mdata)
+{
+    return;
+}
+
 #endif


### PR DESCRIPTION
This PR adds an `else` clause to `vecarith52_special.c`, in line with `vecarith52_common.c`, to escape the AVX-512-only `veckmul_redc` and `vecksqr_redc` ECM vector functions that are causing linking errors on earlier architectures.

Fixes #39