### PR TITLE
Fix: pass `sessionlog` option to driver

### DIFF
--- a/top/driver.c
+++ b/top/driver.c
@@ -137,6 +137,10 @@ int main(int argc, char *argv[])
         strcpy(yafu_obj.batchfilename, options->batchfile);
         batchnum = 1;
     }
+    if (strlen(options->sessionlog) > 0)
+    {
+        strcpy(yafu_obj.sessionname, options->sessionlog);
+    }
     if (options->rand_seed == 0)
     {
         uint32_t seed1, seed2;


### PR DESCRIPTION
The `-session` option is forgotten to pass to driver and thus not enabled.