### PR TITLE
Avoid undefined pointer decrement in big-endian CRC32

### DIFF
--- a/zlib/crc32.c
+++ b/zlib/crc32.c
@@ -278,7 +278,7 @@ local unsigned long crc32_little(crc, buf, len)
 }
 
 /* ========================================================================= */
-#define DOBIG4 c ^= *++buf4; \
+#define DOBIG4 c ^= *buf4++; \
         c = crc_table[4][c & 0xff] ^ crc_table[5][(c >> 8) & 0xff] ^ \
             crc_table[6][(c >> 16) & 0xff] ^ crc_table[7][c >> 24]
 #define DOBIG32 DOBIG4; DOBIG4; DOBIG4; DOBIG4; DOBIG4; DOBIG4; DOBIG4; DOBIG4
@@ -300,7 +300,6 @@ local unsigned long crc32_big(crc, buf, len)
     }
 
     buf4 = (const z_crc_t FAR *)(const void FAR *)buf;
-    buf4--;
     while (len >= 32) {
         DOBIG32;
         len -= 32;
@@ -309,7 +308,6 @@ local unsigned long crc32_big(crc, buf, len)
         DOBIG4;
         len -= 4;
     }
-    buf4++;
     buf = (const unsigned char FAR *)buf4;
 
     if (len) do {


### PR DESCRIPTION
Hi Development Team,

I noticed that the bundled zlib copy used by YAFU in `zlib/crc32.c` still contains the big-endian CRC32 implementation pattern that was flagged in [CVE-2016-9843](https://nvd.nist.gov/vuln/detail/cve-2016-9843). In this code path, the word pointer is pre-decremented before entering the processing loop as part of an old PowerPC-specific optimization. This can move the pointer to one element before the valid buffer, which is undefined behavior in C, even if that location is not dereferenced.

What this PR do:
- Using post-increment when accessing words during the CRC calculation.
- Removing the pre-decrement of the buffer pointer in the big-endian CRC32 path.

Please review at your convenience. Thank you!
