### PR TITLE
Refactor match and end variables in inftrees.c

### DIFF
--- a/zlib/inftrees.c
+++ b/zlib/inftrees.c
@@ -54,7 +54,7 @@ unsigned short FAR *work;
     code FAR *next;             /* next available space in table */
     const unsigned short FAR *base;     /* base value table to use */
     const unsigned short FAR *extra;    /* extra bits table to use */
-    int end;                    /* use base and extra for symbol > end */
+    unsigned match;             /* use base and extra for symbol >= match */
     unsigned short count[MAXBITS+1];    /* number of codes of each length */
     unsigned short offs[MAXBITS+1];     /* offsets in table for each length */
     static const unsigned short lbase[31] = { /* Length codes 257..285 base */
@@ -181,19 +181,17 @@ unsigned short FAR *work;
     switch (type) {
     case CODES:
         base = extra = work;    /* dummy value--not used */
-        end = 19;
+        match = 20;
         break;
     case LENS:
         base = lbase;
-        base -= 257;
         extra = lext;
-        extra -= 257;
-        end = 256;
+        match = 257;
         break;
     default:            /* DISTS */
         base = dbase;
         extra = dext;
-        end = -1;
+        match = 0;
     }
 
     /* initialize state for loop */
@@ -216,13 +214,13 @@ unsigned short FAR *work;
     for (;;) {
         /* create table entry */
         here.bits = (unsigned char)(len - drop);
-        if ((int)(work[sym]) < end) {
+        if (work[sym] + 1 < match) {
             here.op = (unsigned char)0;
             here.val = work[sym];
         }
-        else if ((int)(work[sym]) > end) {
-            here.op = (unsigned char)(extra[work[sym]]);
-            here.val = base[work[sym]];
+        else if (work[sym] >= match) {
+            here.op = (unsigned char)(extra[work[sym] - match]);
+            here.val = base[work[sym] - match];
         }
         else {
             here.op = (unsigned char)(32 + 64);         /* end of block */


### PR DESCRIPTION
## Description

This PR applies the same fix as  
https://github.com/madler/zlib/commit/6a043145ca6e9c55184013841a67b2fef87e44c0

The change removes the offset pointer optimization in `inftrees.c` and replaces it with a C-standard-compliant implementation.

The previous implementation relied on pointer arithmetic that subtracts an offset from a pointer and then indexes from that location. While this worked in practice, it can result in undefined behavior according to the C standard.

---

## Changes

- Removed offset-based pointer arithmetic in `inftrees.c`
- Reworked index calculations to avoid undefined pointer behavior
- Preserved the original logic and behavior while improving safety and portability

---

## Reference

Upstream commit for comparison:  
https://github.com/madler/zlib/commit/6a043145ca6e9c55184013841a67b2fef87e44c0
