### PR TITLE
Fix/lasieve j16 td overflow

### DIFF
--- a/factor/lasieve5_64/asm/lasched.c
+++ b/factor/lasieve5_64/asm/lasched.c
@@ -320,6 +320,22 @@ u32_t*ri,*ij_ptr,*ij_ptr_ub,n1_j,**sched_ptr,fbi_offs,ot,FBsize;
 			vij = _mm512_mask_mov_epi32(vij, (~mri0) & (~mri1) & ((~mri2) | (~mri3)), _mm512_add_epi32(vri2, vri1));
 			vij = _mm512_srli_epi32(_mm512_add_epi32(vij, _mm512_andnot_epi32(vot_tester, vni)), 1);
 
+			// Case D above is ij = ri[0]+ri[1].  With -J 16 both recurrence
+			// vectors can be "tall" (s,t ~ 2^16), so that u32 sum can exceed
+			// 2^32 and wrap, giving a bogus in-range ij and a phantom sieve hit
+			// (the source of the "td" warnings).  The halved value (ij+e)/2
+			// still fits in u32, so recompute the Case D lanes overflow-free
+			// via the average (a+b)/2 = (a&b)+((a^b)>>1), plus e/2 (e is even).
+			{
+				__mmask16 mD = (~mri0) & (~mri1) & ((~mri2) | (~mri3));
+				__m512i ve = _mm512_andnot_epi32(vot_tester, vni);
+				__m512i vijD = _mm512_add_epi32(
+					_mm512_add_epi32(_mm512_and_epi32(vri1, vri2),
+						_mm512_srli_epi32(_mm512_xor_epi32(vri1, vri2), 1)),
+					_mm512_srli_epi32(ve, 1));
+				vij = _mm512_mask_mov_epi32(vij, mD, vijD);
+			}
+
 			__mmask16 mij = _mm512_cmplt_epu32_mask(vij, _mm512_set1_epi32(ij_ub));
 
 #if 1
@@ -402,24 +418,28 @@ u32_t*ri,*ij_ptr,*ij_ptr_ub,n1_j,**sched_ptr,fbi_offs,ot,FBsize;
 #line 102 "lasched.w"
 
 			{
-				ij = 0;
-				if ((ri[0] & ot_mask) == ot_tester)ij = ri[0];
+				// ij0 holds the pre-halving value in 64 bits: the Case D
+				// branch (ri[0]+ri[1]) can exceed 2^32 with -J 16, and halving
+				// in u32 after a wrap yields a bogus in-range ij (phantom hit /
+				// "td" warning).  The halved result still fits in u32.
+				u64_t ij0 = 0;
+				if ((ri[0] & ot_mask) == ot_tester)ij0 = ri[0];
 				else {
-					if ((ri[RI_OFFSET1] & ot_mask) == (ot_tester ^ n_i))ij = ri[RI_OFFSET1];
+					if ((ri[RI_OFFSET1] & ot_mask) == (ot_tester ^ n_i))ij0 = ri[RI_OFFSET1];
 					else {
 						if ((ri[0] & (n_i - 1)) <= (ri[RI_OFFSET1] & (n_i - 1)) && ri[0] <= ri[RI_OFFSET1]) {
 
 
-							if ((ri[0] & (n_i - 1)) == (ri[RI_OFFSET1] & (n_i - 1)))ij = ri[RI_OFFSET1] - ri[0];
-							else ij = n_i;
+							if ((ri[0] & (n_i - 1)) == (ri[RI_OFFSET1] & (n_i - 1)))ij0 = ri[RI_OFFSET1] - ri[0];
+							else ij0 = n_i;
 							if (ot != 2)
 								Schlendrian("Exceptional situation for oddness type %u ?\n",
 									ot);
 						}
-						else ij = ri[0] + ri[RI_OFFSET1];
+						else ij0 = (u64_t)ri[0] + ri[RI_OFFSET1];
 					}
 				}
-				ij = (ij + ((~ot_tester) & n_i)) / 2;
+				ij = (u32_t)((ij0 + ((~ot_tester) & n_i)) / 2);
 			}/*:3*/
 #line 85 "lasched.w"
 

--- a/factor/lasieve5_64/asm/lasched1.asm
+++ b/factor/lasieve5_64/asm/lasched1.asm
@@ -62,11 +62,11 @@ lasched`'ot`'_fbi_loop:
 	cmovnel ad,ijd
 	negl ad
 	negl bd
-	addl aux2d,ijd
+	addq aux2,ij
 	andl $n_i_mask,ad
-	ifelse(ot,1,`addl $n_i,ijd')
+	ifelse(ot,1,`addq $n_i,ij')
 	andl $n_i_mask,bd
-	shrl $1,ijd
+	shrq $1,ij
 	ifelse(ot,2,`cmpl ad,bd
 	jbe lasched2_exception
 lasched2_afterexception:')
@@ -173,11 +173,11 @@ lasched`'ot`'_1_fbi_loop:
 	cmovnel ad,ijd
 	negl ad
 	negl bd
-	addl aux2d,ijd
+	addq aux2,ij
 	andl $n_i_mask,ad
-	ifelse(ot,1,`addl $n_i,ijd')
+	ifelse(ot,1,`addq $n_i,ij')
 	andl $n_i_mask,bd
-	shrl $1,ijd
+	shrq $1,ij
 	ifelse(ot,2,`cmpl ad,bd
 	jbe lasched2_1_exception
 lasched2_1_afterexception:')

--- a/factor/lasieve5_64/gnfs-lasieve4e.c
+++ b/factor/lasieve5_64/gnfs-lasieve4e.c
@@ -976,46 +976,47 @@ int main(int argc, char** argv)
             }
         }
 
-        char features[1024], avx512_features[1024];
-        sprintf(features, "with asm64");
-        sprintf(avx512_features, "avx-512 ");
-        int has_avx512_features = 0;
+        // Build the feature banner by advancing a pointer with each sprintf's
+        // return value.  (The old code did sprintf(buf, "%s...", buf), i.e. the
+        // destination was also a %s source -- undefined behavior that, under
+        // -Ofast/_FORTIFY_SOURCE, collapsed the list down to "(,tdsched)".)
+        char features[1024];
+        char *p = features;
+        char *base_end, *avx_list_start;
+        p += sprintf(p, "with asm64");
+        base_end = p;                  /* end of the always-present part */
+        p += sprintf(p, ",avx-512 ");
+        avx_list_start = p;
 
 #ifdef AVX512_TD
-        sprintf(avx512_features, "%smmx-td,", avx512_features);
-        has_avx512_features = 1;
+        p += sprintf(p, "mmx-td,");
 #endif
 #ifdef AVX512_LASIEVE_SETUP
-        sprintf(avx512_features, "%slasetup,", avx512_features);
-        has_avx512_features = 1;
+        p += sprintf(p, "lasetup,");
 #endif
 #ifdef AVX512_LASCHED
-        sprintf(avx512_features, "%slasched,", avx512_features);
-        has_avx512_features = 1;
+        p += sprintf(p, "lasched,");
 #endif
 #ifdef AVX512_SIEVE1
-        sprintf(avx512_features, "%ssieve1,", avx512_features);
-        has_avx512_features = 1;
+        p += sprintf(p, "sieve1,");
 #endif
 #ifdef AVX512_ECM
-        sprintf(avx512_features, "%secm,", avx512_features);
-        has_avx512_features = 1;
+        p += sprintf(p, "ecm,");
 #endif
 #ifdef AVX512_TDS0
-        sprintf(avx512_features, "%stds0,", avx512_features);
-        has_avx512_features = 1;
+        p += sprintf(p, "tds0,");
 #endif
 #ifdef AVX512_SIEVE_SEARCH
-        sprintf(avx512_features, "%ssearch0,", avx512_features);
-        has_avx512_features = 1;
+        p += sprintf(p, "search0,");
 #endif
 #ifdef AVX512_TDSCHED
-        sprintf(avx512_features, "%stdsched", avx512_features);
-        has_avx512_features = 1;
+        p += sprintf(p, "tdsched,");
 #endif
 
-        if (has_avx512_features)
-            sprintf(features, "%s,%s", features, avx512_features);
+        if (p == avx_list_start)
+            *base_end = '\0';          /* no AVX-512 features: undo ",avx-512 " */
+        else
+            p[-1] = '\0';              /* trim the trailing comma */
 
         if (verbose) { /* first rudimentary test of automatic $Rev reporting */
             fprintf(stderr, "gnfs-lasieve4I%de (%s): L1_BITS=%d\n",


### PR DESCRIPTION
These are the changes I (really claude) made a bit ago to fix the td warnings in both the AVX-512 c code and the older ASM. I also fixed a bug that was causing ggnfs to show that my local version was built with no flags, which was not true. It's what has been running in my client for the last while, so far apparently without issue, but you should definitely take a look, because it's a bit over my head.