### PR TITLE
Add -keep_afb option

### DIFF
--- a/factor/factor_common.c
+++ b/factor/factor_common.c
@@ -246,6 +246,7 @@ void init_factobj(fact_obj_t* fobj)
     fobj->nfs_obj.poly_percent_max = 8;
     fobj->nfs_obj.td = 0;
     fobj->nfs_obj.batch_3lp = 0;
+    fobj->nfs_obj.keep_afb = 0;
     mpz_set_ui(fobj->nfs_obj.snfs_fullinput, 0);
 
     fobj->nfs_obj.polybatch = 250;						//default	
@@ -653,6 +654,7 @@ void copy_factobj(fact_obj_t* dest, fact_obj_t* src, int parameters_only)
     dest->nfs_obj.poly_testsieve = src->nfs_obj.poly_testsieve;
     dest->nfs_obj.td = src->nfs_obj.td;
     dest->nfs_obj.batch_3lp = src->nfs_obj.batch_3lp;
+    dest->nfs_obj.keep_afb = src->nfs_obj.keep_afb;
 
     dest->nfs_obj.polybatch = src->nfs_obj.polybatch;
     strcpy(dest->nfs_obj.ggnfs_dir, src->nfs_obj.ggnfs_dir);

--- a/factor/nfs/nfs.c
+++ b/factor/nfs/nfs.c
@@ -1070,6 +1070,8 @@ void nfs(fact_obj_t *fobj)
 			sprintf(tmpstr, "%s.d",fobj->nfs_obj.outputfile);	remove(tmpstr);
 			sprintf(tmpstr, "%s.ranges", fobj->nfs_obj.outputfile);	remove(tmpstr);
 			sprintf(tmpstr, "%s.mat.chk",fobj->nfs_obj.outputfile);	remove(tmpstr);
+			snprintf(tmpstr, sizeof(tmpstr), "%s.afb.0",fobj->nfs_obj.job_infile);	remove(tmpstr);
+			snprintf(tmpstr, sizeof(tmpstr), "%s.afb.1",fobj->nfs_obj.job_infile);	remove(tmpstr);
 
 			if (fobj->nfs_obj.cadoMsieve) {
 				remove("nfs.poly");

--- a/factor/nfs/nfs_sieving.c
+++ b/factor/nfs/nfs_sieving.c
@@ -1988,8 +1988,159 @@ uint32_t process_batch(nfs_threaddata_t* thread_data, mpz_ptr prime_prod, char *
 	return rb->num_success;
 }
 
+// The lattice sievers auto-load <jobfile>.afb.<side> whenever the file
+// exists (no command line switch needed), so a factor base cache must only
+// ever be on disk in a form that any siever in ggnfs_dir can use safely.
+// Sievers with cache validation append a 20-byte trailer (magic 0xafb00004)
+// when writing the cache, verify it against the current poly/params when
+// reading, and trim a full-alim cache down to the lowered FB bound that
+// applies while special-q < alim. Older sievers do none of this: they would
+// load a full-alim cache untrimmed at q < alim and silently produce a
+// different relation set. The trailer is therefore used as the capability
+// test: prime the cache once per nfs() run, and if the file comes back
+// without a trailer the siever is too old to trust with one.
+// these must match the trailer the sievers write: AFB_EXT_WORDS u32s
+// ending the file, the first of which is AFB_EXT_MAGIC (gnfs-lasieve4e.c)
+#define AFB_TRAILER_BYTES 20
+#define AFB_TRAILER_MAGIC 0xafb00004u
+
+// classify <jobfile>.afb.0: 1 = complete with validation trailer,
+// 0 = complete legacy format (pre-validation siever), -1 = missing/malformed
+static int nfs_afb_cache_kind(const char* afbname)
+{
+	FILE* f;
+	uint32_t fbsize, magic;
+	long len, legacy;
+
+	f = fopen(afbname, "rb");
+	if (f == NULL)
+		return -1;
+	if (fread(&fbsize, sizeof(uint32_t), 1, f) != 1)
+	{
+		fclose(f);
+		return -1;
+	}
+	if (fseek(f, 0, SEEK_END) != 0 || (len = ftell(f)) < 0)
+	{
+		fclose(f);
+		return -1;
+	}
+	// legacy layout: [u32 count][count primes][count roots][u32 xFB count]
+	legacy = (long)(2 * sizeof(uint32_t) + 2 * (size_t)fbsize * sizeof(uint32_t));
+	if (len == legacy + AFB_TRAILER_BYTES)
+	{
+		if (fseek(f, -AFB_TRAILER_BYTES, SEEK_END) != 0 ||
+			fread(&magic, sizeof(uint32_t), 1, f) != 1)
+		{
+			fclose(f);
+			return -1;
+		}
+		fclose(f);
+		return (magic == AFB_TRAILER_MAGIC) ? 1 : -1;
+	}
+	fclose(f);
+	return (len == legacy) ? 0 : -1;
+}
+
+// a cache we've decided not to trust must actually be gone: whatever
+// siever runs next would auto-load it
+static void nfs_afb_remove(const char* afbname)
+{
+	if (remove(afbname) != 0 && errno != ENOENT)
+	{
+		printf("nfs: could not remove %s (%s); sievers will auto-load it!\n",
+			afbname, strerror(errno));
+	}
+}
+
+static void nfs_afb_prime_cache(fact_obj_t* fobj, nfs_job_t* job)
+{
+	char afbname[GSTR_MAXSIZE + 8];
+	char syscmd[2 * GSTR_MAXSIZE + 32];
+
+	snprintf(afbname, sizeof(afbname), "%s.afb.0", fobj->nfs_obj.job_infile);
+
+	if (!fobj->nfs_obj.keep_afb)
+	{
+		// a cache left behind by an earlier keep_afb run (or seeded by hand)
+		// would still be auto-loaded by whatever siever runs next, so don't
+		// leave one around unless the user asked for caching
+		if (remove(afbname) == 0)
+		{
+			if (fobj->VFLAG > 0)
+				printf("nfs: removed factor base cache %s (keep_afb not set)\n",
+					afbname);
+		}
+		else if (errno != ENOENT)
+		{
+			printf("nfs: could not remove %s (%s); sievers will auto-load it!\n",
+				afbname, strerror(errno));
+		}
+		return;
+	}
+
+	if (job->afb_cache_state != 0)
+		return;		// already primed (1) or disabled (-1) for this job
+
+	// -c 0 builds the factor bases and exits without sieving anything;
+	// unlike a normal sieving run it skips the q-dependent FB_bound
+	// lowering, so the cache holds the complete factor base up to alim
+	// no matter where sieving starts. -F overwrites any stale file.
+	if (fobj->VFLAG > 0)
+		printf("nfs: building factor base cache %s\n", afbname);
+	snprintf(syscmd, sizeof(syscmd), "%s -b %s -k -c 0 -F",
+		job->sievername, fobj->nfs_obj.job_infile);
+	if (fobj->VFLAG > 1) printf("syscmd: %s\n", syscmd);
+	fflush(stdout);
+
+	if (system(syscmd) != 0)
+	{
+		// don't inspect what a failed call left behind: a stale but
+		// well-formed cache from an earlier job could pass the checks
+		if (fobj->VFLAG >= 0)
+			printf("nfs: factor base cache generation failed; "
+				"continuing without a cache\n");
+		logprint_oc(fobj->flogname, "a",
+			"nfs: factor base cache generation failed; keep_afb disabled\n");
+		nfs_afb_remove(afbname);
+		job->afb_cache_state = -1;
+		return;
+	}
+
+	switch (nfs_afb_cache_kind(afbname))
+	{
+	case 1:
+		job->afb_cache_state = 1;
+		logprint_oc(fobj->flogname, "a",
+			"nfs: factor base cache ready: %s\n", afbname);
+		break;
+	case 0:
+		if (fobj->VFLAG >= 0)
+			printf("nfs: %s does not support factor base cache validation; "
+				"ignoring keep_afb (update the sievers in ggnfs_dir to enable it)\n",
+				job->sievername);
+		logprint_oc(fobj->flogname, "a",
+			"nfs: siever lacks factor base cache validation; keep_afb disabled\n");
+		nfs_afb_remove(afbname);
+		job->afb_cache_state = -1;
+		break;
+	default:
+		if (fobj->VFLAG >= 0)
+			printf("nfs: unrecognized factor base cache format; "
+				"continuing without a cache\n");
+		logprint_oc(fobj->flogname, "a",
+			"nfs: unrecognized factor base cache format; keep_afb disabled\n");
+		nfs_afb_remove(afbname);
+		job->afb_cache_state = -1;
+		break;
+	}
+}
+
 void do_sieving_nfs(fact_obj_t *fobj, nfs_job_t *job)
 {
+	// settle the factor base cache (build it, or remove a disallowed one)
+	// before any siever process is launched that could auto-load it
+	nfs_afb_prime_cache(fobj, job);
 
 #ifdef USE_THREADPOOL
 
@@ -2231,22 +2382,6 @@ void do_sieving_nfs(fact_obj_t *fobj, nfs_job_t *job)
             fclose(logfile);
         }
     }
-
-	if (0)
-	{
-		// it would be faster to write the .afb once rather than
-		// recompute it for every qrange that is run.  But if it
-		// doesn't get deleted when the job completes that could
-		// be problematic.  Need a way to query if existing .afb's
-		// are valid for the current run.  Not sure how to do that yet.
-		char syscmd[1024];
-		
-		sprintf(syscmd, "%s -b %s -k -c 0 -F", job->sievername, fobj->nfs_obj.job_infile);
-
-		if (fobj->VFLAG > 1) printf("syscmd: %s\n", syscmd);
-		if (fobj->VFLAG > 1) fflush(stdout);
-		system(syscmd);
-	}
 
 	// create a new lasieve process in each thread and watch it
 	for (i = 0; i < fobj->THREADS; i++)

--- a/include/factor.h
+++ b/include/factor.h
@@ -365,6 +365,7 @@ typedef struct
     int poly_testsieve;
     int poly_percent_max;
     int batch_3lp;
+    int keep_afb;          // reuse the siever factor base cache (<jobfile>.afb.0) across q-ranges
 
 	double gnfs_exponent;
 	double gnfs_multiplier;

--- a/include/nfs_impl.h
+++ b/include/nfs_impl.h
@@ -161,6 +161,8 @@ typedef struct
     struct timeval jobstart;
     snfs_t* snfs; // NULL if GNFS
     int filenumber;
+    int afb_cache_state;    // factor base cache: 0 = not primed yet, 1 = primed
+                            // and validated, -1 = disabled for this job
 } nfs_job_t;
 
 typedef struct {

--- a/top/cmdParser/cmdOptions.c
+++ b/top/cmdParser/cmdOptions.c
@@ -84,7 +84,7 @@ char OptionArray[NUMOPTIONS][MAXOPTIONLEN] = {
     "obase", "minrels", "stopk", "stop_strict", "terse",
     "max_siqs", "max_nfs", "np1", "nps", "npr",
     "nfs_params", "poly_testsieve", "poly_percent_max", "td", "jsonlog",
-    "forceQLP", "siqsMFBQ", "nfs_batch_3lp", "analysis"};
+    "forceQLP", "siqsMFBQ", "nfs_batch_3lp", "analysis", "keep_afb"};
 
 // help strings displayed with -h
 // needs to be the same length as the above arrays, even if 
@@ -218,7 +218,8 @@ char OptionHelp[NUMOPTIONS][MAXHELPLEN] = {
     "                  : force the use of QLP SIQS (4 large primes)",
     "(Floating point)  : Exponent of SIQS QLP: attempt to split residues up to LPB^exponent",
     "                  : Use batch factorization of 3LP cofactors in NFS",
-    "(Integer < 32-bit): analysis type for the sieve of Eratosthenes (default = 1 (find primes), 2 (find twins)"
+    "(Integer < 32-bit): analysis type for the sieve of Eratosthenes (default = 1 (find primes), 2 (find twins)",
+    "                  : NFS: build the siever factor base cache once per job (needs sievers with cache validation)"
 };
 
 // indication of whether or not an option needs a corresponding argument.
@@ -252,7 +253,7 @@ int needsArg[NUMOPTIONS] = {
     1,1,1,0,0,   //"obase", "minrels", "stopk", "stop_strict", "terse"
     1,1,0,0,0,   // "max_siqs", "max_nfs", "np1", "nps", "npr"
     1,1,1,1,1,   // "nfs_params", "poly_testsieve", "poly_percent_thresh", "td", "jsonlog"
-    0,1,0,1       // forceQLP, qlp_exp, nfs_batch_3lp, soe analysis
+    0,1,0,1,0     // forceQLP, qlp_exp, nfs_batch_3lp, soe analysis, keep_afb
 };
 
 // command line option aliases, specified by '--'
@@ -284,7 +285,7 @@ char LongOptionAliases[NUMOPTIONS][MAXOPTIONLEN] = {
     "", "", "", "", "",
     "", "", "", "", "",
     "", "", "", "", "",
-    "", "", "", ""
+    "", "", "", "", ""
 };
 
 
@@ -1295,6 +1296,15 @@ void applyOpt(char* opt, char* arg, options_t* options)
         //argument "forceQLP"
         options->soe_analysis  = atoi(arg);
     }
+    else if (strcmp(opt, OptionArray[129]) == 0)
+    {
+        //argument "keep_afb": bare flag enables; an explicit value
+        //(e.g. keep_afb=0 in an ini file) is respected
+        if (arg == NULL || strlen(arg) == 0)
+            options->keep_afb = 1;
+        else
+            options->keep_afb = (atoi(arg) != 0);
+    }
     else
     {
         int i;
@@ -1432,7 +1442,8 @@ options_t* initOpt(void)
     options->poly_percent_max = 8;
     options->poly_testsieve = 390;
     options->nfs_batch_3lp = 0;
-    
+    options->keep_afb = 0;
+
     // prime finding options
     options->soe_blocksize = 32768;
     options->aprcl_p = 500;

--- a/top/cmdParser/cmdOptions.h
+++ b/top/cmdParser/cmdOptions.h
@@ -38,7 +38,7 @@ extern "C" {
 #include <stdint.h>
 
     // the number of recognized command line options
-#define NUMOPTIONS 129
+#define NUMOPTIONS 130
 // maximum length of command line option strings
 #define MAXOPTIONLEN 20
 // maximum length of help string for each option
@@ -159,6 +159,7 @@ typedef struct
     int poly_percent_max;
     int poly_testsieve;
     int nfs_batch_3lp;
+    int keep_afb;
 
     // ecm/pp1/pm1/rho/tdiv options
     uint64_t B1pm1;

--- a/top/driver.c
+++ b/top/driver.c
@@ -1779,6 +1779,7 @@ void options_to_factobj(fact_obj_t* fobj, options_t* options)
     fobj->nfs_obj.poly_percent_max = options->poly_percent_max;
     fobj->nfs_obj.poly_testsieve = options->poly_testsieve;
     fobj->nfs_obj.batch_3lp = options->nfs_batch_3lp;
+    fobj->nfs_obj.keep_afb = options->keep_afb;
 
     // raise min_rels bounds by a percentage
     // on unsuccessful filtering


### PR DESCRIPTION
Below are the notes from Claude. I've tested this a few times and it seems to work, but you should as well. I didn't test it nearly as seriously as I tested ggnfs itself!

Like I mentioned before, you can also discard this if you have your own version, this is mostly to show how the new ggnfs works.

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Build the siever factor base cache once per job and reuse it

The lattice sievers can already write the algebraic factor base to <jobfile>.afb.0 (-k) and auto-load it on any later run, but a cache written during a normal sieving run at special-q < alim only reaches q0-1 and must not be reused. Instead, prime the cache once per nfs() run before the sieving threads launch, using the siever's "-c 0" mode (build the complete factor base up to alim, sieve nothing; this mode skips the q-dependent FB_bound lowering). Every subsequent siever invocation then auto-loads the file and, on sievers with cache validation, trims it in memory to the current q-range's bound. This replaces the disabled prototype block in do_sieving_nfs, whose comment asked for a way to tell whether an existing .afb is valid.

Sievers without cache validation would load a full-alim cache untrimmed at q < alim and silently produce a different relation set (measured: 432 vs 395 relations over the same q-range, with 3 correct relations missing). To keep that from ever happening, the file the priming call produces is used as the capability test: sievers with validation append a 20-byte trailer (magic 0xafb00004), and if it is absent the siever is too old to trust with a cache -- the file is deleted, a message tells the user to update their sievers, and sieving continues exactly as before, recomputing the factor base per range. A priming call that exits nonzero is treated the same way, so a stale cache from an earlier job is never mistaken for a fresh one. When -keep_afb is off (the default), any leftover .afb.0 is likewise removed before sieving so no siever can pick up a stale cache. The cache is rebuilt (-F) once per nfs() run, so siever or parameter changes between sessions are always picked up, and it is deleted with the other temporary files when the job completes.

Note: the trailer is written by sievers carrying the .afb validation changes (PR "afb-validation-checks"). With the sievers currently shipped in the tree, -keep_afb detects the missing trailer and safely disables itself.